### PR TITLE
fix: abort downloads of oversized thumbnails

### DIFF
--- a/packages/comprima-adapter/README.md
+++ b/packages/comprima-adapter/README.md
@@ -22,3 +22,7 @@ curl -X PUT http://localhost:9200/comprima-prod-3
 ```shell
 npm run dev
 ```
+
+## Configuration
+
+Some thumbnails in Cromprima are actually video files, some of them over 1 GB in size. We currently have no need for these "thumbnails" and they are also causing problems, because the comprima-adapter will attempt downloading them entirely (and storing them in RAM) before deciding they are not going to be saved anyway. Therefore we configure Axios with a maxContentLength of 20 MB. This limit is configurable using the `THUMBNAIL_MAX_SIZE_MB` env variable.

--- a/packages/comprima-adapter/src/services/indexingService/index.ts
+++ b/packages/comprima-adapter/src/services/indexingService/index.ts
@@ -1,12 +1,12 @@
-import { Client } from '@elastic/elasticsearch'
-import { promises as fs } from 'fs'
-import axios from 'axios'
+import { Client } from '@elastic/elasticsearch';
+import { promises as fs } from 'fs';
+import axios, { AxiosError } from 'axios';
 
-import { Document } from '../../common/types'
+import { Document } from '../../common/types';
 
 const client = new Client({
-  node: process.env.ELASTICSEARCH_URL || 'http://localhost:9200'
-})
+  node: process.env.ELASTICSEARCH_URL || 'http://localhost:9200',
+});
 
 const thumbnailTypes = [
   'image/jpeg',
@@ -18,41 +18,71 @@ const thumbnailTypes = [
   'image/avif',
   'image/svg',
   'image/svg+xml',
-]
+];
+
+const maxContentLengthMB = process.env.THUMBNAIL_MAX_SIZE_MB || '20';
+const maxContentLength = parseInt(maxContentLengthMB) * 1_000_000;
 
 const saveThumbnail = async (document: Document) => {
   if (document.pages[0].thumbnailUrl) {
-    const response = await axios.get(document.pages[0].thumbnailUrl, { responseType: 'arraybuffer' })
+    try {
+      const response = await axios.get(document.pages[0].thumbnailUrl, {
+        responseType: 'arraybuffer',
+        maxContentLength,
+      });
 
-    if (thumbnailTypes.includes(response.headers['content-type'].toLowerCase())) {
-      await fs.writeFile(process.cwd() + '/../thumbnails/' + document.id + '.jpg', response.data, 'binary')
-      return true
-    } else {
-      console.error('Rejected thumbnail type', response.headers['content-type'].toLowerCase())
+      if (
+        thumbnailTypes.includes(response.headers['content-type'].toLowerCase())
+      ) {
+        await fs.writeFile(
+          process.cwd() + '/../thumbnails/' + document.id + '.jpg',
+          response.data,
+          'binary'
+        );
+        return true;
+      } else {
+        console.error(
+          'Rejected thumbnail type',
+          response.headers['content-type'].toLowerCase()
+        );
+      }
+    } catch (error: AxiosError | any) {
+      const errorString = error.toString();
+
+      if (errorString.includes('maxContentLength size of')) {
+        console.debug(
+          'Aborting download of oversized thumbnail file',
+          errorString
+        );
+        return true;
+      }
+
+      console.error(error);
+      return false;
     }
   }
 
-  return false
-}
+  return false;
+};
 
 const indexDocument = async (document: Document) => {
   try {
-    const hasValidThumbnail = await saveThumbnail(document)
+    const hasValidThumbnail = await saveThumbnail(document);
 
     if (!hasValidThumbnail) {
-      document.pages[0].thumbnailUrl = undefined
+      document.pages[0].thumbnailUrl = undefined;
     }
 
     await client.index({
       index: 'comprima',
       id: document.id.toString(),
-      document
-    })
+      document,
+    });
   } catch (err) {
-    console.error(err)
+    console.error(err);
   }
-}
+};
 
 export default {
-  indexDocument
-}
+  indexDocument,
+};


### PR DESCRIPTION
Try using level `34913`.

This will save a lot of RAM. While indexing level `34913` comprima-adapter would momentarily consume over 2 GB of RAM, causing problems in the kubernetes cluster. While limiting Axios requests to 20 MB it never rose above 500 MB.