### PR TITLE
Fix 112-Pagination hide last page link

### DIFF
--- a/packages/reading-room-frontend/src/routes/search/components/searchResult.tsx
+++ b/packages/reading-room-frontend/src/routes/search/components/searchResult.tsx
@@ -207,6 +207,8 @@ export function SearchResult({
               '.MuiPaginationItem-page': { marginTop: '4px' },
             }}
             siblingCount={4}
+            boundaryCount={0}
+            showFirstButton={true}
           />
         )}
       </Box>
@@ -397,6 +399,8 @@ export function SearchResult({
               '.MuiPaginationItem-page': { marginTop: '4px' },
             }}
             siblingCount={4}
+            boundaryCount={0}
+            showFirstButton={true}
           />
         )}
       </Box>


### PR DESCRIPTION
* Elastic can only handle 10000 results with this type of pagination
* To encourgae the user to use filter and sort functionality instead of looking at really big search results, the link to the last page has been remove