### PR TITLE
Removed depositor entry

### DIFF
--- a/packages/reading-room-search/src/services/authenticationService/index.ts
+++ b/packages/reading-room-search/src/services/authenticationService/index.ts
@@ -234,8 +234,7 @@ export const routes = (router: KoaRouter) => {
         lastName: ctx.request.body.lastName as string,
         password_hash: password,
         salt,
-        depositors:
-          'Centrum för Näringslivshistoria;Föreningen Stockholms Företagsminnen',
+        depositors: 'Föreningen Stockholms Företagsminnen',
         organization: ctx.request.body.organization as string,
         role: 'User',
       }

--- a/packages/reading-room-search/src/services/authenticationService/tests/index.test.ts
+++ b/packages/reading-room-search/src/services/authenticationService/tests/index.test.ts
@@ -196,8 +196,7 @@ describe('authenticationService', () => {
         username: 'foo',
         firstName: 'bar',
         lastName: 'barsson',
-        depositors:
-          'Centrum för Näringslivshistoria;Föreningen Stockholms Företagsminnen',
+        depositors: 'Föreningen Stockholms Företagsminnen',
         organization: 'FooBar AB',
         role: 'User',
         password_hash: mockHash.password,


### PR DESCRIPTION
Removes "Centrum för Näringslivshistoria" from default depositors when registering new account.