### PR TITLE
Feat/184 stream documents

### DIFF
--- a/packages/comprima-adapter/src/services/comprimaService/comprimaAdapter.ts
+++ b/packages/comprima-adapter/src/services/comprimaService/comprimaAdapter.ts
@@ -356,7 +356,7 @@ const getDocument = async (documentId: number): Promise<Document> => {
 
 const getAttachment = async (document: Document) => {
   const attachment = await axios.get(document.pages[0].url, {
-    responseType: 'arraybuffer',
+    responseType: 'stream',
   })
   return attachment
 }

--- a/packages/comprima-adapter/src/services/comprimaService/index.ts
+++ b/packages/comprima-adapter/src/services/comprimaService/index.ts
@@ -3,6 +3,8 @@ import KoaRouter from '@koa/router'
 import { Document } from '../../common/types'
 import comprimaAdapter from './comprimaAdapter'
 
+import { Readable } from 'stream'
+
 const batchSize = 10
 
 const healthCheck = async () => {
@@ -70,10 +72,11 @@ export const routes = (router: KoaRouter) => {
         parseInt(ctx.params.documentId)
       )
       const attachment = await comprimaAdapter.getAttachment(document)
+      const attachmentStream = attachment.data as Readable
 
       ctx.type =
         document.fields.format?.value ?? attachment.headers['content-type']
-      ctx.body = attachment.data
+      ctx.body = attachmentStream
     } catch (err) {
       ctx.status = 500
       ctx.body = { results: 'error: ' + err }


### PR DESCRIPTION
- Changed the response type for document attachments from 'arraybuffer' to 'stream' in the getAttachment function.
- Updated the route handler to correctly set the response body to the attachment stream, enhancing the document retrieval process.