### PR TITLE
Refactor Document Viewer to support scaling and rotation and minor view fixes

### DIFF
--- a/packages/reading-room-frontend/package-lock.json
+++ b/packages/reading-room-frontend/package-lock.json
@@ -9716,19 +9716,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/yet-another-react-lightbox": {
-      "version": "3.21.7",
-      "resolved": "https://registry.npmjs.org/yet-another-react-lightbox/-/yet-another-react-lightbox-3.21.7.tgz",
-      "integrity": "sha512-dcdokNuCIl92f0Vl+uzeKULnQhztIGpoZFUMvtVNUPmtwsQWpqWufeieDPeg9JtFyVCcbj4vYw3V00DS0QNoWA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "dev": true,
@@ -15850,12 +15837,6 @@
       "dev": true,
       "optional": true,
       "peer": true
-    },
-    "yet-another-react-lightbox": {
-      "version": "3.21.7",
-      "resolved": "https://registry.npmjs.org/yet-another-react-lightbox/-/yet-another-react-lightbox-3.21.7.tgz",
-      "integrity": "sha512-dcdokNuCIl92f0Vl+uzeKULnQhztIGpoZFUMvtVNUPmtwsQWpqWufeieDPeg9JtFyVCcbj4vYw3V00DS0QNoWA==",
-      "requires": {}
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/packages/reading-room-frontend/src/common/types.ts
+++ b/packages/reading-room-frontend/src/common/types.ts
@@ -77,6 +77,8 @@ interface ViewerContentProps {
   thumbnailUrl?: string
   isLoading: boolean
   setIsLoading: (isLoading: boolean) => void
+  scale?: number
+  rotation?: number
 }
 
 interface NavigationButtonsProps {
@@ -102,6 +104,8 @@ interface VideoPlayerProps {
   file: {
     url: string
   }
+  scale?: number
+  rotation?: number
 }
 
 interface ThumbnailImageProps {

--- a/packages/reading-room-frontend/src/routes/search/components/documentViewer/components/VideoPlayer.tsx
+++ b/packages/reading-room-frontend/src/routes/search/components/documentViewer/components/VideoPlayer.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from '@mui/material'
 
 import { VideoPlayerProps } from '../../../../../common/types'
 
-export const VideoPlayer = ({ file }: VideoPlayerProps) => {
+export const VideoPlayer = ({ file, scale, rotation }: VideoPlayerProps) => {
   if (file.url.endsWith('.flv')) {
     return (
       <Typography variant="h6" sx={{ color: 'white' }}>
@@ -29,6 +29,7 @@ export const VideoPlayer = ({ file }: VideoPlayerProps) => {
           maxWidth: '100%',
           maxHeight: '100%',
           objectFit: 'contain',
+          transform: `scale(${scale || 1}) rotate(${rotation || 0}deg)`,
         }}
         controlsList="nodownload"
       >

--- a/packages/reading-room-frontend/src/routes/search/components/documentViewer/index.tsx
+++ b/packages/reading-room-frontend/src/routes/search/components/documentViewer/index.tsx
@@ -284,7 +284,7 @@ export default function DocumentViewer({
 
           <Box
             sx={{
-              transform: `scale(${scale}) translate(${position.x}px, ${position.y}px) rotate(${rotation}deg)`,
+              transform: `translate(${position.x}px, ${position.y}px)`,
               transition: isDragging ? 'none' : 'transform 0.3s ease-in-out',
               transformOrigin: 'center center',
               padding: '50px',
@@ -306,6 +306,8 @@ export default function DocumentViewer({
               thumbnailUrl={thumbnailUrl}
               isLoading={isLoading}
               setIsLoading={setIsLoading}
+              scale={scale}
+              rotation={rotation}
             />
           </Box>
         </Box>


### PR DESCRIPTION
Uses scaling on PDF library to get better quality when zooming.
Makes full content visible in initial view without cropping.

- Removed unused dependency `yet-another-react-lightbox` from package-lock.json.
- Updated ViewerContentProps and VideoPlayerProps interfaces to include optional `scale` and `rotation` properties.
- Modified DocumentViewer, VideoPlayer, and ViewerContent components to utilize `scale` and `rotation` for transforming content display.