### PR TITLE
Lägg till saknade sökfält i standardsökning

### DIFF
--- a/packages/reading-room-search/src/services/searchService/queryFunctions.ts
+++ b/packages/reading-room-search/src/services/searchService/queryFunctions.ts
@@ -204,11 +204,15 @@ export const createSearchQuery = (
       query_string: {
         query: queryString,
         lenient: true,
-        ...(includeAiGeneratedDescription
-          ? {}
-          : {
-              fields: ['fields.*.value', 'attachmentType', 'pages.pageType', 'ocrContent'],
-            }),
+        fields: [
+          'fields.*',
+          'attachmentType',
+          'pages.pageType',
+          'level',
+          'ocrContent',
+          'ocrText',
+          ...(includeAiGeneratedDescription ? ['ocrDescription'] : []),
+        ],
       },
     })
   }


### PR DESCRIPTION
Commit e0b1bbc begränsade sökningen till specifika fält men missade t.ex ocrText med gammal OCR-data.

- Lagt till ocrText och level
- Breddat fields.*.value till fields.*
- Explicit fältlista används alltid, checkboxen togglar enbart ocrDescription