### PR TITLE
#244 Läs användarbehörighet från DB istället för att skriva till/läsa från cookie

### DIFF
--- a/packages/reading-room-search/package.json
+++ b/packages/reading-room-search/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "@babel/core": "^7.28.3",
     "@types/http-errors": "^2.0.5",
-    "@types/koa-session": "^6.4.5",
     "@types/node": "^18.14.0",
     "@types/pg": "^8.6.6",
     "eslint": "^8.13.0",
@@ -57,7 +56,6 @@
     "koa": "^2.15.4",
     "koa-jwt": "^4.0.4",
     "koa-pino-logger": "^4.0.0",
-    "koa-session": "^6.4.0",
     "nodemailer": "^6.9.7",
     "pg": "^8.9.0",
     "ts-node": "^10.7.0"

--- a/packages/reading-room-search/pnpm-lock.yaml
+++ b/packages/reading-room-search/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       koa-pino-logger:
         specifier: ^4.0.0
         version: 4.0.0
-      koa-session:
-        specifier: ^6.4.0
-        version: 6.4.0
       nodemailer:
         specifier: ^6.9.7
         version: 6.10.1
@@ -96,9 +93,6 @@ importers:
       '@types/http-errors':
         specifier: ^2.0.5
         version: 2.0.5
-      '@types/koa-session':
-        specifier: ^6.4.5
-        version: 6.4.5
       '@types/node':
         specifier: ^18.14.0
         version: 18.19.127
@@ -891,9 +885,6 @@ packages:
   '@types/koa-pino-logger@3.0.5':
     resolution: {integrity: sha512-gQuPV/npT9Mns95NNBF6WaHhQjydjhJxr6TCTssgm12ZyB9+mUImGcuaIQoEJQK0JdVFzVy+XbWE5qc28WCIdw==}
 
-  '@types/koa-session@6.4.5':
-    resolution: {integrity: sha512-Vc6+fslnPuMH2v9y80WYeo39UMo8mweuNNthKCwYU2ZE6l5vnRrzRU3BRvexKwsoI5sxsRl5CxDsBlLI8kY/XA==}
-
   '@types/koa@2.15.0':
     resolution: {integrity: sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==}
 
@@ -1197,9 +1188,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -1234,9 +1222,6 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1377,12 +1362,6 @@ packages:
   cookies@0.9.1:
     resolution: {integrity: sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==}
     engines: {node: '>= 0.8'}
-
-  core-util-is@1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
-  crc@3.8.0:
-    resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -1988,9 +1967,6 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
   ignore-by-default@1.0.1:
     resolution: {integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==}
 
@@ -2060,9 +2036,6 @@ packages:
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
-
-  is-class-hotfix@0.0.6:
-    resolution: {integrity: sha512-0n+pzCC6ICtVr/WXnN2f03TK/3BfXY7me4cjCAqT8TYXEl0+JBRoqBo94JJHXcyDSLUeWbNX8Fvy5g5RJdAstQ==}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -2155,9 +2128,6 @@ packages:
     resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
     engines: {node: '>= 0.4'}
 
-  is-type-of@1.4.0:
-    resolution: {integrity: sha512-EddYllaovi5ysMLMEN7yzHEKh8A850cZ7pykrY1aNRQGn/CDjRDE9qEWbIdt7xGEVJmjBXzU/fNnC4ABTm8tEQ==}
-
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
@@ -2182,9 +2152,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isstream@0.1.2:
-    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -2460,10 +2427,6 @@ packages:
 
   koa-pino-logger@4.0.0:
     resolution: {integrity: sha512-YI/LB9ajyLPpjvf6e+7Ewmn+OQkCJpu/Y9eI1n7fnipu5Y1NchuNlke0mqh3/2z+5oDYr7pijjOWruEDIfua2A==}
-
-  koa-session@6.4.0:
-    resolution: {integrity: sha512-h/dxmSOvNEXpHQPRs4TV03TZVFyZIjmYQiTAW5JBFTYBOZ0VdpZ8QEE6Dud75g8z9JNGXi3m++VqRmqToB+c2A==}
-    engines: {node: '>=8.0.0'}
 
   koa-unless@1.0.7:
     resolution: {integrity: sha512-NKiz+nk4KxSJFskiJMuJvxeA41Lcnx3d8Zy+8QETgifm4ab4aOeGD3RgR6bIz0FGNWwo3Fz0DtnK77mEIqHWxA==}
@@ -3444,10 +3407,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -4872,11 +4831,6 @@ snapshots:
       '@types/pino': 6.3.12
       '@types/pino-http': 5.8.4
 
-  '@types/koa-session@6.4.5':
-    dependencies:
-      '@types/cookies': 0.9.1
-      '@types/koa': 2.15.0
-
   '@types/koa@2.15.0':
     dependencies:
       '@types/accepts': 1.3.7
@@ -5010,7 +4964,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      debug: 4.3.4
+      debug: 4.4.3
       eslint: 8.57.1
     optionalDependencies:
       typescript: 4.9.5
@@ -5287,8 +5241,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  base64-js@1.5.1: {}
-
   binary-extensions@2.3.0: {}
 
   bowser@2.12.1: {}
@@ -5322,11 +5274,6 @@ snapshots:
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   bytes@3.1.2: {}
 
@@ -5462,12 +5409,6 @@ snapshots:
     dependencies:
       depd: 2.0.0
       keygrip: 1.1.0
-
-  core-util-is@1.0.3: {}
-
-  crc@3.8.0:
-    dependencies:
-      buffer: 5.7.1
 
   create-require@1.1.1: {}
 
@@ -6162,8 +6103,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1: {}
-
   ignore-by-default@1.0.1: {}
 
   ignore@5.3.2: {}
@@ -6229,8 +6168,6 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-callable@1.2.7: {}
-
-  is-class-hotfix@0.0.6: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -6313,12 +6250,6 @@ snapshots:
       has-symbols: 1.1.0
       safe-regex-test: 1.1.0
 
-  is-type-of@1.4.0:
-    dependencies:
-      core-util-is: 1.0.3
-      is-class-hotfix: 0.0.6
-      isstream: 0.1.2
-
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.19
@@ -6339,8 +6270,6 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
-
-  isstream@0.1.2: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -6868,15 +6797,6 @@ snapshots:
   koa-pino-logger@4.0.0:
     dependencies:
       pino-http: 6.6.0
-
-  koa-session@6.4.0:
-    dependencies:
-      crc: 3.8.0
-      debug: 4.4.3
-      is-type-of: 1.4.0
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - supports-color
 
   koa-unless@1.0.7: {}
 
@@ -7868,8 +7788,6 @@ snapshots:
       requires-port: 1.0.0
 
   util-deprecate@1.0.2: {}
-
-  uuid@8.3.2: {}
 
   uuid@9.0.1: {}
 

--- a/packages/reading-room-search/src/api.ts
+++ b/packages/reading-room-search/src/api.ts
@@ -1,7 +1,6 @@
 import KoaRouter from '@koa/router'
 import { routes as searchRoutes } from './services/searchService'
 import { routes as documentRoutes } from './services/documentService'
-import { fetchUserData } from './services/userService'
 
 const router = new KoaRouter()
 
@@ -10,40 +9,19 @@ documentRoutes(router)
 
 router.get('(.*)/auth/is-logged-in', async (ctx) => {
   if (ctx.state?.user?.username) {
-    try {
-      const userData = await fetchUserData(ctx.state.user.username)
+    const user = ctx.state.user
 
-      if (userData.locked || userData.disabled) {
-        ctx.status = 401
-        ctx.body = {
-          error: `User is ${userData.locked ? 'locked' : 'disabled'}`,
-        }
-        return
-      }
-
-      if (ctx.session) {
-        ctx.session.user = {
-          ...ctx.session.user,
-          ...userData,
-        }
-      }
-
-      ctx.body = {
-        username: ctx.state.user.username,
-        firstName: userData.firstName,
-        lastName: userData.lastName,
-        organization: userData.organization,
-        depositors: userData.depositors,
-        archiveInitiators: userData.archiveInitiators,
-        documentIds: userData.documentIds,
-        series: userData.series,
-        volumes: userData.volumes,
-        fileNames: userData.fileNames,
-      }
-    } catch (error) {
-      console.error('Error fetching user data:', error)
-      ctx.status = 500
-      ctx.body = { error: 'Failed to fetch user data' }
+    ctx.body = {
+      username: user.username,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      organization: user.organization,
+      depositors: user.depositors,
+      archiveInitiators: user.archiveInitiators,
+      documentIds: user.documentIds,
+      series: user.series,
+      volumes: user.volumes,
+      fileNames: user.fileNames,
     }
   } else {
     ctx.status = 401

--- a/packages/reading-room-search/src/app.ts
+++ b/packages/reading-room-search/src/app.ts
@@ -3,16 +3,13 @@ import KoaRouter from '@koa/router'
 import bodyParser from '@koa/bodyparser'
 import cors from '@koa/cors'
 import jwt from 'koa-jwt'
-import session from 'koa-session'
 
 import api from './api'
 import { routes as authRoutes } from './services/authenticationService'
 import config from './common/config'
-import { populateUserStateFromSession } from './services/middleware/authMiddleware'
+import { populateUserState } from './services/middleware/authMiddleware'
 
 const app = new Koa()
-
-app.keys = [process.env.SESSION_SECRET || 'dev-session-secret']
 
 app.use(
   cors({
@@ -23,26 +20,13 @@ app.use(
 
 app.use(bodyParser())
 
-app.use(
-  session(
-    {
-      key: 'koa.sess',
-      maxAge: 86400000,
-      httpOnly: true,
-      secure: false,
-      sameSite: 'lax',
-    },
-    app
-  )
-)
-
 const publicRouter = new KoaRouter()
 authRoutes(publicRouter)
 app.use(publicRouter.routes())
 
 app.use(jwt({ secret: config.auth.secret, cookie: 'readingroom' }))
 
-app.use(populateUserStateFromSession)
+app.use(populateUserState)
 
 app.use(api.routes())
 

--- a/packages/reading-room-search/src/services/authenticationService/index.ts
+++ b/packages/reading-room-search/src/services/authenticationService/index.ts
@@ -17,7 +17,6 @@ import {
 } from '../../common/adapters/userAdapter'
 import { User } from '../../common/types'
 import config from '../../common/config'
-import { fetchUserData } from '../userService'
 
 const cookieOptions = {
   httpOnly: true,
@@ -107,14 +106,6 @@ export const routes = (router: KoaRouter) => {
 
       ctx.cookies.set('readingroom', token, cookieOptions)
 
-      const userData = await fetchUserData(username)
-      if (ctx.session) {
-        ctx.session.user = {
-          username,
-          ...userData,
-        }
-      }
-
       ctx.body = { message: 'Login successful' }
     } catch (error) {
       if (createHttpError.isHttpError(error)) {
@@ -129,7 +120,6 @@ export const routes = (router: KoaRouter) => {
 
   router.get('(.*)/auth/logout', async (ctx) => {
     ctx.cookies.set('readingroom', null, cookieOptions)
-    ctx.session = null
     ctx.redirect('/login')
   })
 

--- a/packages/reading-room-search/src/services/authenticationService/tests/index.test.ts
+++ b/packages/reading-room-search/src/services/authenticationService/tests/index.test.ts
@@ -2,11 +2,9 @@ import request from 'supertest'
 import Koa from 'koa'
 import KoaRouter from '@koa/router'
 import bodyParser from '@koa/bodyparser'
-import session from 'koa-session'
 import { routes } from '../index'
 import hash from '../hash'
 import * as jwt from '../jwt'
-import * as userService from '../../userService'
 import * as userAdapter from '../../../common/adapters/userAdapter'
 import * as smtpAdapter from '../../../common/adapters/smtpAdapter'
 import dotenv from 'dotenv'
@@ -14,20 +12,6 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 const app = new Koa()
-app.keys = [process.env.SESSION_SECRET || 'dev-session-secret']
-
-app.use(
-  session(
-    {
-      key: 'koa.sess',
-      maxAge: 86400000,
-      httpOnly: true,
-      secure: false,
-      sameSite: 'lax',
-    },
-    app
-  )
-)
 
 app.use(bodyParser())
 
@@ -109,19 +93,6 @@ describe('authenticationService', () => {
     it('anropar createToken med användarnamn och lösenord', async () => {
       const token = 'abc123'
       const jwtSpy = jest.spyOn(jwt, 'createToken').mockResolvedValue({ token })
-      const userDataSpy = jest
-        .spyOn(userService, 'fetchUserData')
-        .mockResolvedValue({
-          firstName: 'Test',
-          lastName: 'User',
-          organization: 'Test Org',
-          depositors: ['Dep1', 'Dep2'],
-          archiveInitiators: [],
-          series: [],
-          volumes: [],
-          documentIds: [],
-          fileNames: [],
-        })
 
       const res = await request(app.callback()).post('/auth/login').send({
         username: 'foo',
@@ -129,25 +100,13 @@ describe('authenticationService', () => {
       })
 
       expect(jwtSpy).toBeCalledWith('foo', 'bar')
-      expect(userDataSpy).toBeCalledWith('foo')
       expect(res.status).toBe(200)
       expect(res.body).toEqual({ message: 'Login successful' })
     })
 
-    it('sätter sessionen och cookie vid lyckad inloggning', async () => {
+    it('sätter readingroom-cookien men ingen sessionscookie vid lyckad inloggning', async () => {
       const token = 'abc123'
       jest.spyOn(jwt, 'createToken').mockResolvedValue({ token })
-      jest.spyOn(userService, 'fetchUserData').mockResolvedValue({
-        firstName: 'Test',
-        lastName: 'User',
-        organization: 'Test Org',
-        depositors: ['Dep1', 'Dep2'],
-        archiveInitiators: [],
-        series: [],
-        volumes: [],
-        documentIds: [],
-        fileNames: [],
-      })
 
       const res = await request(app.callback()).post('/auth/login').send({
         username: 'foo',
@@ -156,6 +115,8 @@ describe('authenticationService', () => {
 
       expect(res.headers['set-cookie']).toBeDefined()
       expect(res.headers['set-cookie'][0]).toContain('readingroom')
+      const cookies = res.headers['set-cookie'] as unknown as string[]
+      expect(cookies.some((cookie) => cookie.includes('koa.sess'))).toBe(false)
     })
   })
 

--- a/packages/reading-room-search/src/services/authenticationService/tests/index.test.ts
+++ b/packages/reading-room-search/src/services/authenticationService/tests/index.test.ts
@@ -114,8 +114,8 @@ describe('authenticationService', () => {
       })
 
       expect(res.headers['set-cookie']).toBeDefined()
-      expect(res.headers['set-cookie'][0]).toContain('readingroom')
       const cookies = res.headers['set-cookie'] as unknown as string[]
+      expect(cookies.some((cookie) => cookie.includes('readingroom'))).toBe(true)
       expect(cookies.some((cookie) => cookie.includes('koa.sess'))).toBe(false)
     })
   })

--- a/packages/reading-room-search/src/services/middleware/authMiddleware.ts
+++ b/packages/reading-room-search/src/services/middleware/authMiddleware.ts
@@ -13,7 +13,8 @@ export const populateUserState = async (ctx: Context, next: Next) => {
     userData = await fetchUserData(ctx.state.user.username)
   } catch (error) {
     console.error('Error fetching user data:', error)
-    ctx.status = 401
+    ctx.status = 500
+    ctx.body = { error: 'Internal server error' }
     return
   }
 

--- a/packages/reading-room-search/src/services/middleware/authMiddleware.ts
+++ b/packages/reading-room-search/src/services/middleware/authMiddleware.ts
@@ -1,6 +1,7 @@
 import { Context, Next } from 'koa'
 
 import { fetchUserData } from '../userService'
+import { User } from '../../common/types'
 
 export const populateUserState = async (ctx: Context, next: Next) => {
   if (!ctx.state.user?.username) {
@@ -8,7 +9,7 @@ export const populateUserState = async (ctx: Context, next: Next) => {
     return
   }
 
-  let userData
+  let userData: Partial<User> | null = null
   try {
     userData = await fetchUserData(ctx.state.user.username)
   } catch (error) {

--- a/packages/reading-room-search/src/services/middleware/authMiddleware.ts
+++ b/packages/reading-room-search/src/services/middleware/authMiddleware.ts
@@ -1,13 +1,35 @@
 import { Context, Next } from 'koa'
 
-export const populateUserStateFromSession = async (
-  ctx: Context,
-  next: Next
-) => {
-  if (ctx.session && ctx.session.user) {
-    ctx.state.user = ctx.session.user
-  } else {
-    ctx.state.user = {}
+import { fetchUserData } from '../userService'
+
+export const populateUserState = async (ctx: Context, next: Next) => {
+  if (!ctx.state.user?.username) {
+    ctx.status = 401
+    return
   }
+
+  let userData
+  try {
+    userData = await fetchUserData(ctx.state.user.username)
+  } catch (error) {
+    console.error('Error fetching user data:', error)
+    ctx.status = 401
+    return
+  }
+
+  if (!userData) {
+    ctx.status = 401
+    return
+  }
+
+  if (userData.locked || userData.disabled) {
+    ctx.status = 401
+    ctx.body = {
+      error: `User is ${userData.locked ? 'locked' : 'disabled'}`,
+    }
+    return
+  }
+
+  ctx.state.user = { ...ctx.state.user, ...userData }
   await next()
 }

--- a/packages/reading-room-search/src/services/middleware/tests/authMiddleware.test.ts
+++ b/packages/reading-room-search/src/services/middleware/tests/authMiddleware.test.ts
@@ -87,13 +87,36 @@ describe('populateUserState', () => {
     expect(res.body).toEqual({ error: 'User is disabled' })
   })
 
-  it('svarar 401 om användaren inte finns', async () => {
-    mockedFetchUserData.mockRejectedValue(new Error('User not found'))
+  it('svarar 500 vid oväntat fel under hämtning av användardata', async () => {
+    mockedFetchUserData.mockRejectedValue(new Error('DB connection failed'))
+
+    const res = await request(app.callback())
+      .get('/whoami')
+      .set('Authorization', 'Bearer ' + createToken())
+
+    expect(res.status).toBe(500)
+    expect(res.body).toEqual({ error: 'Internal server error' })
+  })
+
+  it('svarar 401 om användaren inte finns i databasen', async () => {
+    mockedFetchUserData.mockResolvedValue(null)
 
     const res = await request(app.callback())
       .get('/whoami')
       .set('Authorization', 'Bearer ' + createToken())
 
     expect(res.status).toBe(401)
+  })
+
+  it('når inte next() vid oväntat DB-fel', async () => {
+    mockedFetchUserData.mockRejectedValue(new Error('DB connection failed'))
+
+    const res = await request(app.callback())
+      .get('/whoami')
+      .set('Authorization', 'Bearer ' + createToken())
+
+    expect(res.status).toBe(500)
+    expect(res.body).toEqual({ error: 'Internal server error' })
+    expect(res.body.username).toBeUndefined()
   })
 })

--- a/packages/reading-room-search/src/services/middleware/tests/authMiddleware.test.ts
+++ b/packages/reading-room-search/src/services/middleware/tests/authMiddleware.test.ts
@@ -1,0 +1,99 @@
+import request from 'supertest'
+import Koa from 'koa'
+import KoaRouter from '@koa/router'
+import koaJwt from 'koa-jwt'
+import jwt from 'jsonwebtoken'
+
+import { populateUserState } from '../authMiddleware'
+import * as userService from '../../userService'
+
+jest.mock('../../userService', () => ({
+  fetchUserData: jest.fn(),
+}))
+
+const mockedFetchUserData = userService.fetchUserData as jest.Mock
+
+const secret = 'test-secret'
+
+const app = new Koa()
+app.use(koaJwt({ secret, cookie: 'readingroom' }))
+app.use(populateUserState)
+
+const router = new KoaRouter()
+router.get('/whoami', async (ctx) => {
+  ctx.body = ctx.state.user
+})
+app.use(router.routes())
+
+const createToken = () =>
+  jwt.sign({ sub: '1', username: 'foo', role: 'User' }, secret, {
+    expiresIn: '1h',
+  })
+
+describe('populateUserState', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('populerar ctx.state.user från databasen utan att sätta någon sessionscookie', async () => {
+    const manyDepositors = Array.from(
+      { length: 100 },
+      (_, i) => `Deponent med ett ganska långt namn nummer ${i}`
+    )
+    mockedFetchUserData.mockResolvedValue({
+      firstName: 'Test',
+      lastName: 'User',
+      organization: 'Test Org',
+      depositors: manyDepositors,
+      archiveInitiators: [],
+      series: [],
+      volumes: [],
+      documentIds: [],
+      fileNames: [],
+      locked: false,
+      disabled: false,
+    })
+
+    const res = await request(app.callback())
+      .get('/whoami')
+      .set('Authorization', 'Bearer ' + createToken())
+
+    expect(mockedFetchUserData).toBeCalledWith('foo')
+    expect(res.status).toBe(200)
+    expect(res.body.username).toBe('foo')
+    expect(res.body.depositors).toEqual(manyDepositors)
+    expect(res.headers['set-cookie']).toBeUndefined()
+  })
+
+  it('svarar 401 om användaren är låst', async () => {
+    mockedFetchUserData.mockResolvedValue({ locked: true, disabled: false })
+
+    const res = await request(app.callback())
+      .get('/whoami')
+      .set('Authorization', 'Bearer ' + createToken())
+
+    expect(res.status).toBe(401)
+    expect(res.body).toEqual({ error: 'User is locked' })
+  })
+
+  it('svarar 401 om användaren är inaktiverad', async () => {
+    mockedFetchUserData.mockResolvedValue({ locked: false, disabled: true })
+
+    const res = await request(app.callback())
+      .get('/whoami')
+      .set('Authorization', 'Bearer ' + createToken())
+
+    expect(res.status).toBe(401)
+    expect(res.body).toEqual({ error: 'User is disabled' })
+  })
+
+  it('svarar 401 om användaren inte finns', async () => {
+    mockedFetchUserData.mockRejectedValue(new Error('User not found'))
+
+    const res = await request(app.callback())
+      .get('/whoami')
+      .set('Authorization', 'Bearer ' + createToken())
+
+    expect(res.status).toBe(401)
+  })
+})

--- a/packages/reading-room-search/src/services/userService/index.ts
+++ b/packages/reading-room-search/src/services/userService/index.ts
@@ -2,7 +2,7 @@ import { getUserData } from '../../common/adapters/userAdapter'
 import { User } from '../../common/types'
 
 const userCache = new Map<string, { data: Partial<User>; expiresAt: number }>()
-const CACHE_TTL_MS = 60 * 1000;
+const CACHE_TTL_MS = 60 * 1000
 
 export const fetchUserData = async (
   username: string

--- a/packages/reading-room-search/src/services/userService/index.ts
+++ b/packages/reading-room-search/src/services/userService/index.ts
@@ -1,33 +1,42 @@
 import { getUserData } from '../../common/adapters/userAdapter'
 import { User } from '../../common/types'
 
+const userCache = new Map<string, { data: Partial<User>; expiresAt: number }>()
+const CACHE_TTL_MS = 60 * 1000;
+
 export const fetchUserData = async (
   username: string
-): Promise<Partial<User>> => {
-  try {
-    const userData = await getUserData(username)
-
-    const parseField = (field: string | null | undefined): string[] => {
-      return field ? field.replace(/;$/, '').split(';') : []
-    }
-
-    const parsedUserData: Partial<User> = {
-      ...userData,
-      depositors: parseField(userData.depositors as string | null | undefined),
-      archiveInitiators: parseField(
-        userData.archiveInitiators as string | null | undefined
-      ),
-      series: parseField(userData.series as string | null | undefined),
-      volumes: parseField(userData.volumes as string | null | undefined),
-      documentIds: parseField(
-        userData.documentIds as string | null | undefined
-      ),
-      fileNames: parseField(userData.fileNames as string | null | undefined),
-    }
-
-    return parsedUserData
-  } catch (error) {
-    console.error('Error fetching user data:', error)
-    throw error
+): Promise<Partial<User> | null> => {
+  const cached = userCache.get(username)
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.data
   }
+
+  const userData = await getUserData(username)
+  if (!userData) {
+    return null
+  }
+
+  const parseField = (field: string | null | undefined): string[] => {
+    return field ? field.replace(/;$/, '').split(';') : []
+  }
+
+  const parsedUserData: Partial<User> = {
+    ...userData,
+    depositors: parseField(userData.depositors as string | null | undefined),
+    archiveInitiators: parseField(
+      userData.archiveInitiators as string | null | undefined
+    ),
+    series: parseField(userData.series as string | null | undefined),
+    volumes: parseField(userData.volumes as string | null | undefined),
+    documentIds: parseField(userData.documentIds as string | null | undefined),
+    fileNames: parseField(userData.fileNames as string | null | undefined),
+  }
+
+  userCache.set(username, {
+    data: parsedUserData,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  })
+
+  return parsedUserData
 }

--- a/packages/reading-room-search/src/services/userService/tests/userService.test.ts
+++ b/packages/reading-room-search/src/services/userService/tests/userService.test.ts
@@ -1,0 +1,29 @@
+import * as userAdapter from '../../../common/adapters/userAdapter'
+import { fetchUserData } from '..'
+
+jest.mock('../../../common/adapters/userAdapter', () => ({
+  getUserData: jest.fn(),
+}))
+const mockedGetUserData = userAdapter.getUserData as jest.Mock
+
+afterEach(() => jest.clearAllMocks())
+
+it('hämtar från cache inom TTL', async () => {
+  mockedGetUserData.mockResolvedValue({ depositors: 'a;b;', locked: false })
+
+  await fetchUserData('cache-hit-user')
+  await fetchUserData('cache-hit-user')
+
+  expect(mockedGetUserData).toHaveBeenCalledTimes(1)
+})
+
+it('cachar inte saknad användare', async () => {
+  mockedGetUserData.mockResolvedValue(undefined)
+
+  const first = await fetchUserData('missing-user')
+  const second = await fetchUserData('missing-user')
+
+  expect(first).toBeNull()
+  expect(second).toBeNull()
+  expect(mockedGetUserData).toHaveBeenCalledTimes(2)
+})


### PR DESCRIPTION
1. Read user access information from db by having authMiddleware.ts use existing fetchUserData instead of the koa browser cookie
2. Remove the koa-session cookie writes, keep the signed jwt cookie 'readingroom'
3. Remove the koa-session package from reading-room-search