### PR TITLE
Bug/245 video files only play audio

### DIFF
--- a/packages/comprima-adapter/Dockerfile
+++ b/packages/comprima-adapter/Dockerfile
@@ -10,6 +10,7 @@ FROM node:18.14.1-alpine AS runner
 
 # Install pnpm
 WORKDIR /app
+RUN apk add --no-cache ffmpeg
 RUN corepack enable && corepack prepare pnpm@10.17.0 --activate
 
 COPY . .

--- a/packages/comprima-adapter/package.json
+++ b/packages/comprima-adapter/package.json
@@ -7,7 +7,7 @@
     "node": "18.14.1"
   },
   "scripts": {
-    "test": "jest --slient=false",
+    "test": "jest --silent=false",
     "test:watch": "jest --watch",
     "start": "ts-node -r dotenv/config ./src/index.ts",
     "dev": "nodemon -e ts,js --exec pnpm start",

--- a/packages/comprima-adapter/src/services/comprimaService/comprimaAdapter.ts
+++ b/packages/comprima-adapter/src/services/comprimaService/comprimaAdapter.ts
@@ -354,9 +354,10 @@ const getDocument = async (documentId: number): Promise<Document> => {
   }
 }
 
-const getAttachment = async (document: Document) => {
+const getAttachment = async (document: Document, rangeHeader?: string) => {
   const attachment = await axios.get(document.pages[0].url, {
     responseType: 'stream',
+    headers: rangeHeader ? { Range: rangeHeader } : {},
   })
   return attachment
 }

--- a/packages/comprima-adapter/src/services/comprimaService/comprimaAdapter.ts
+++ b/packages/comprima-adapter/src/services/comprimaService/comprimaAdapter.ts
@@ -357,7 +357,7 @@ const getDocument = async (documentId: number): Promise<Document> => {
 const getAttachment = async (document: Document, rangeHeader?: string) => {
   const attachment = await axios.get(document.pages[0].url, {
     responseType: 'stream',
-    headers: rangeHeader ? { Range: rangeHeader } : {},
+    ...(rangeHeader ? { headers: { Range: rangeHeader } } : {}),
   })
   return attachment
 }

--- a/packages/comprima-adapter/src/services/comprimaService/index.ts
+++ b/packages/comprima-adapter/src/services/comprimaService/index.ts
@@ -72,14 +72,26 @@ export const routes = (router: KoaRouter) => {
     }
 
     try {
+      const rangeHeader = ctx.request.headers['range'] as string | undefined
       const document = await comprimaAdapter.getDocument(
         parseInt(ctx.params.documentId)
       )
-      const attachment = await comprimaAdapter.getAttachment(document)
+      const attachment = await comprimaAdapter.getAttachment(document, rangeHeader)
       const attachmentStream = attachment.data as Readable
 
       ctx.type =
         document.fields.format?.value ?? attachment.headers['content-type']
+
+      if (attachment.headers['content-range']) {
+        ctx.response.set('content-range', attachment.headers['content-range'])
+      }
+      if (attachment.headers['accept-ranges']) {
+        ctx.response.set('accept-ranges', attachment.headers['accept-ranges'])
+      }
+      if (attachment.status === 206) {
+        ctx.status = 206
+      }
+
       ctx.body = attachmentStream
     } catch (err) {
       ctx.status = 500

--- a/packages/comprima-adapter/src/services/comprimaService/index.ts
+++ b/packages/comprima-adapter/src/services/comprimaService/index.ts
@@ -3,7 +3,12 @@ import KoaRouter from '@koa/router'
 import { Document } from '../../common/types'
 import comprimaAdapter from './comprimaAdapter'
 
-import { Readable } from 'stream'
+import { Readable, PassThrough } from 'stream'
+import { spawn } from 'child_process'
+import { createWriteStream, createReadStream, unlink } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomBytes } from 'crypto'
 
 const batchSize = 10
 
@@ -79,8 +84,8 @@ export const routes = (router: KoaRouter) => {
       const attachment = await comprimaAdapter.getAttachment(document, rangeHeader)
       const attachmentStream = attachment.data as Readable
 
-      ctx.type =
-        document.fields.format?.value ?? attachment.headers['content-type']
+      const contentType = document.fields.format?.value ?? attachment.headers['content-type'] ?? ''
+      const isMp4 = contentType.toLowerCase().includes('mp4')
 
       if (attachment.headers['content-range']) {
         ctx.response.set('content-range', attachment.headers['content-range'])
@@ -92,7 +97,60 @@ export const routes = (router: KoaRouter) => {
         ctx.status = 206
       }
 
-      ctx.body = attachmentStream
+      if (isMp4) {
+        const tmpPath = join(tmpdir(), `comprima-mp4-${randomBytes(8).toString('hex')}.mp4`)
+        const output = new PassThrough()
+        let cleanedUp = false
+        const cleanup = () => {
+          if (!cleanedUp) {
+            cleanedUp = true
+            unlink(tmpPath, () => {})
+          }
+        }
+
+        // Buffer to disk so ffmpeg can seek backwards to the moov atom (not seekable via pipe)
+        const fileWrite = createWriteStream(tmpPath)
+        attachmentStream.pipe(fileWrite)
+        await new Promise<void>((resolve, reject) => {
+          fileWrite.on('finish', resolve)
+          fileWrite.on('error', reject)
+          attachmentStream.on('error', reject)
+        })
+
+        const ffmpeg = spawn('ffmpeg', [
+          '-hide_banner',
+          '-loglevel', 'error',
+          '-i', tmpPath,
+          '-map', '0:v:0',
+          '-map', '0:a:0',
+          '-c:v', 'libx264',
+          '-preset', 'fast',
+          '-crf', '23',
+          '-c:a', 'copy',
+          '-movflags', 'frag_keyframe+empty_moov',
+          '-f', 'mp4',
+          'pipe:1',
+        ])
+        ffmpeg.stderr.on('data', (data) => console.error('[ffmpeg]', data.toString()))
+        let useFallback = false
+        ffmpeg.on('error', (err) => {
+          useFallback = true
+          console.warn('ffmpeg unavailable, falling back to direct stream:', err.message)
+          const fallback = createReadStream(tmpPath)
+          fallback.pipe(output)
+          fallback.on('close', cleanup)
+        })
+        ffmpeg.stdout.pipe(output)
+        ffmpeg.on('close', () => {
+          if (!useFallback) cleanup()
+        })
+
+        ctx.type = 'video/mp4'
+        ctx.body = output
+      } else {
+        ctx.type = contentType
+        ctx.body = attachmentStream
+      }
     } catch (err) {
       ctx.status = 500
       ctx.body = { results: 'error: ' + err }

--- a/packages/comprima-adapter/src/services/comprimaService/index.ts
+++ b/packages/comprima-adapter/src/services/comprimaService/index.ts
@@ -12,6 +12,12 @@ import { randomBytes } from 'crypto'
 
 const batchSize = 10
 
+// video/mp4 only — never a bare includes('mp4'), which wrongly catches audio/mp4.
+const isTranscodableVideo = (t: string) => {
+  const v = t.toLowerCase()
+  return v.startsWith('video/') && v.includes('mp4')
+}
+
 const healthCheck = async () => {
   await comprimaAdapter.getDocuments('34913', 0, 1)
 }
@@ -81,30 +87,49 @@ export const routes = (router: KoaRouter) => {
       const document = await comprimaAdapter.getDocument(
         parseInt(ctx.params.documentId)
       )
-      const attachment = await comprimaAdapter.getAttachment(document, rangeHeader)
+
+      // The document format is the authoritative content type and is available
+      // before fetching the attachment, which lets us decide whether to
+      // transcode. Only a video/mp4 is transcoded — audio/mp4 (and any other
+      // audio type) must pass through untouched, since the ffmpeg branch maps a
+      // mandatory video stream (0:v:0) that audio-only files do not have.
+      let contentType = document.fields.format?.value ?? ''
+      let isVideoMp4 = isTranscodableVideo(contentType)
+
+      // We withhold the Range header for video/mp4 because that branch buffers
+      // and transcodes the whole file. Note this is NOT what protects ffmpeg
+      // from a truncated slice: the 47% of video docs with no `format` are
+      // pre-decided as non-video here (empty format) and so DO get Range
+      // forwarded upstream — they only flip to transcode after the post-fetch
+      // header check below. That is safe purely because Comprima ignores Range
+      // entirely and always returns 200 + the full file; byte-range serving
+      // never actually happens on the final hop.
+      const attachment = await comprimaAdapter.getAttachment(
+        document,
+        isVideoMp4 ? undefined : rangeHeader
+      )
       const attachmentStream = attachment.data as Readable
 
-      const contentType = document.fields.format?.value ?? attachment.headers['content-type'] ?? ''
-      const isMp4 = contentType.toLowerCase().includes('mp4')
-
-      if (attachment.headers['content-range']) {
-        ctx.response.set('content-range', attachment.headers['content-range'])
-      }
-      if (attachment.headers['accept-ranges']) {
-        ctx.response.set('accept-ranges', attachment.headers['accept-ranges'])
-      }
-      if (attachment.status === 206) {
-        ctx.status = 206
+      if (!contentType) {
+        // Edge case: format hint missing, fall back to the upstream content
+        // type. Comprima returns Content-Type: video/mp4 for these no-MIME
+        // docs, so this fallback covers them. The startsWith('video/') guard in
+        // isTranscodableVideo also hardens this path: a stray audio/mp4 response
+        // is correctly rejected here rather than pushed into the ffmpeg branch.
+        contentType = attachment.headers['content-type'] ?? ''
+        isVideoMp4 = isTranscodableVideo(contentType)
       }
 
-      if (isMp4) {
+      if (isVideoMp4) {
         const tmpPath = join(tmpdir(), `comprima-mp4-${randomBytes(8).toString('hex')}.mp4`)
         const output = new PassThrough()
         let cleanedUp = false
         const cleanup = () => {
           if (!cleanedUp) {
             cleanedUp = true
-            unlink(tmpPath, () => {})
+            unlink(tmpPath, () => {
+              /* best-effort cleanup; ignore errors */
+            })
           }
         }
 
@@ -122,7 +147,7 @@ export const routes = (router: KoaRouter) => {
           '-loglevel', 'error',
           '-i', tmpPath,
           '-map', '0:v:0',
-          '-map', '0:a:0',
+          '-map', '0:a:0?',
           '-c:v', 'libx264',
           '-preset', 'fast',
           '-crf', '23',
@@ -141,13 +166,36 @@ export const routes = (router: KoaRouter) => {
           fallback.on('close', cleanup)
         })
         ffmpeg.stdout.pipe(output)
+
+        // Kill ffmpeg and clean up if the client disconnects mid-stream so the
+        // CPU-intensive process does not run to completion for an aborted request.
+        const abort = () => {
+          ffmpeg.kill('SIGKILL')
+          output.destroy()
+          cleanup()
+        }
+        ctx.req.on('close', abort)
         ffmpeg.on('close', () => {
+          ctx.req.off('close', abort)
           if (!useFallback) cleanup()
         })
 
+        // The transcoded stream is a fragmented MP4 of a different length than
+        // the source, so the original byte offsets are invalid. Respond 200 and
+        // tell the browser not to attempt range requests against it.
         ctx.type = 'video/mp4'
+        ctx.response.set('accept-ranges', 'none')
         ctx.body = output
       } else {
+        if (attachment.headers['content-range']) {
+          ctx.response.set('content-range', attachment.headers['content-range'])
+        }
+        if (attachment.headers['accept-ranges']) {
+          ctx.response.set('accept-ranges', attachment.headers['accept-ranges'])
+        }
+        if (attachment.status === 206) {
+          ctx.status = 206
+        }
         ctx.type = contentType
         ctx.body = attachmentStream
       }

--- a/packages/comprima-adapter/src/services/comprimaService/index.ts
+++ b/packages/comprima-adapter/src/services/comprimaService/index.ts
@@ -83,7 +83,7 @@ export const routes = (router: KoaRouter) => {
     }
 
     try {
-      const rangeHeader = ctx.request.headers['range'] as string | undefined
+      const rangeHeader = ctx.request.headers['range']
       const document = await comprimaAdapter.getDocument(
         parseInt(ctx.params.documentId)
       )
@@ -133,14 +133,48 @@ export const routes = (router: KoaRouter) => {
           }
         }
 
-        // Buffer to disk so ffmpeg can seek backwards to the moov atom (not seekable via pipe)
-        const fileWrite = createWriteStream(tmpPath)
+        // Buffer to disk so ffmpeg can seek backwards to the moov atom (not
+        // seekable via pipe). 0o600 keeps the temp file, which may hold
+        // restricted archive content, owner-only.
+        const fileWrite = createWriteStream(tmpPath, { mode: 0o600 })
+
+        // If the client disconnects during buffering, the post-spawn abort
+        // handler does not exist yet and 'close' is never replayed — destroy
+        // the streams (with an error, so the buffering promise below settles)
+        // to avoid transcoding for a dead request.
+        let clientGone = false
+        const onClientClose = () => {
+          clientGone = true
+          attachmentStream.destroy(
+            new Error('client disconnected during buffering')
+          )
+          fileWrite.destroy()
+          cleanup()
+        }
+        ctx.req.on('close', onClientClose)
+
         attachmentStream.pipe(fileWrite)
         await new Promise<void>((resolve, reject) => {
+          // cleanup() is not wired to the request/ffmpeg lifecycle yet, so a
+          // buffering error would otherwise leak the temp file — and pipe()
+          // does not destroy the sibling stream, which would leak its fd (and
+          // the unlinked file's disk space) too.
+          const fail = (err: Error) => {
+            fileWrite.destroy()
+            attachmentStream.destroy()
+            cleanup()
+            reject(err)
+          }
           fileWrite.on('finish', resolve)
-          fileWrite.on('error', reject)
-          attachmentStream.on('error', reject)
+          fileWrite.on('error', fail)
+          attachmentStream.on('error', fail)
         })
+
+        ctx.req.off('close', onClientClose)
+        if (clientGone || ctx.req.destroyed) {
+          cleanup()
+          return
+        }
 
         const ffmpeg = spawn('ffmpeg', [
           '-hide_banner',
@@ -164,8 +198,17 @@ export const routes = (router: KoaRouter) => {
           const fallback = createReadStream(tmpPath)
           fallback.pipe(output)
           fallback.on('close', cleanup)
+          fallback.on('error', (e) => {
+            output.destroy(e)
+            cleanup()
+          })
         })
-        ffmpeg.stdout.pipe(output)
+        // When spawn fails, stdout ends immediately; a plain pipe would end
+        // `output` before the fallback's data flows, producing an empty 200
+        ffmpeg.stdout.pipe(output, { end: false })
+        ffmpeg.stdout.on('end', () => {
+          if (!useFallback) output.end()
+        })
 
         // Kill ffmpeg and clean up if the client disconnects mid-stream so the
         // CPU-intensive process does not run to completion for an aborted request.
@@ -175,7 +218,12 @@ export const routes = (router: KoaRouter) => {
           cleanup()
         }
         ctx.req.on('close', abort)
-        ffmpeg.on('close', () => {
+        ffmpeg.on('close', (code) => {
+          if (code !== 0 && !useFallback) {
+            console.error(
+              `[ffmpeg] exited with code ${code} for document ${ctx.params.documentId}`
+            )
+          }
           ctx.req.off('close', abort)
           if (!useFallback) cleanup()
         })

--- a/packages/comprima-adapter/src/services/comprimaService/index.ts
+++ b/packages/comprima-adapter/src/services/comprimaService/index.ts
@@ -18,6 +18,14 @@ const isTranscodableVideo = (t: string) => {
   return v.startsWith('video/') && v.includes('mp4')
 }
 
+// A 206 means a byte range; so does a Content-Range on a 200, which a
+// non-compliant upstream can send. Either way the body is a slice, and a slice
+// must never reach the transcoder.
+const isPartialResponse = (response: {
+  status: number
+  headers: Record<string, unknown>
+}) => response.status === 206 || Boolean(response.headers['content-range'])
+
 const healthCheck = async () => {
   await comprimaAdapter.getDocuments('34913', 0, 1)
 }
@@ -93,32 +101,85 @@ export const routes = (router: KoaRouter) => {
       // transcode. Only a video/mp4 is transcoded — audio/mp4 (and any other
       // audio type) must pass through untouched, since the ffmpeg branch maps a
       // mandatory video stream (0:v:0) that audio-only files do not have.
-      let contentType = document.fields.format?.value ?? ''
+      const formatContentType = document.fields.format?.value ?? ''
+      let contentType = formatContentType
       let isVideoMp4 = isTranscodableVideo(contentType)
 
       // We withhold the Range header for video/mp4 because that branch buffers
-      // and transcodes the whole file. Note this is NOT what protects ffmpeg
-      // from a truncated slice: the 47% of video docs with no `format` are
-      // pre-decided as non-video here (empty format) and so DO get Range
+      // and transcodes the whole file. The 47% of video docs with no `format`
+      // are pre-decided as non-video here (empty format) and so DO get Range
       // forwarded upstream — they only flip to transcode after the post-fetch
-      // header check below. That is safe purely because Comprima ignores Range
-      // entirely and always returns 200 + the full file; byte-range serving
-      // never actually happens on the final hop.
-      const attachment = await comprimaAdapter.getAttachment(
+      // header check below. Comprima ignores Range today and always answers
+      // 200 + the full file, but that is an external, unenforced invariant, so
+      // the partial-response guard after the type check re-fetches rather than
+      // trusting it. Keep what we actually sent: only a forwarded Range makes a
+      // Range-less retry worth attempting.
+      const forwardedRange = isVideoMp4 ? undefined : rangeHeader
+      let attachment = await comprimaAdapter.getAttachment(
         document,
-        isVideoMp4 ? undefined : rangeHeader
+        forwardedRange
       )
-      const attachmentStream = attachment.data as Readable
 
-      if (!contentType) {
-        // Edge case: format hint missing, fall back to the upstream content
-        // type. Comprima returns Content-Type: video/mp4 for these no-MIME
-        // docs, so this fallback covers them. The startsWith('video/') guard in
-        // isTranscodableVideo also hardens this path: a stray audio/mp4 response
-        // is correctly rejected here rather than pushed into the ffmpeg branch.
+      // Edge case: format hint missing, fall back to the upstream content type.
+      // Comprima returns Content-Type: video/mp4 for these no-MIME docs, so this
+      // fallback covers them. The startsWith('video/') guard in
+      // isTranscodableVideo also hardens this path: a stray audio/mp4 response is
+      // correctly rejected here rather than pushed into the ffmpeg branch. Run
+      // again after a re-fetch, so the decision always describes the body we are
+      // about to serve rather than the discarded one.
+      const resolveTypeFromUpstream = () => {
+        if (formatContentType) return
         contentType = attachment.headers['content-type'] ?? ''
         isVideoMp4 = isTranscodableVideo(contentType)
       }
+
+      resolveTypeFromUpstream()
+
+      const refusePartialBody = () => {
+        console.error(
+          `Refusing to transcode a partial body for document ${ctx.params.documentId}`
+        )
+        ctx.status = 502
+        ctx.body = {
+          errorMessage:
+            'Upstream returned a partial response for a video attachment; cannot transcode a partial body',
+          documentId: ctx.params.documentId,
+        }
+      }
+
+      if (isVideoMp4 && isPartialResponse(attachment)) {
+        // Feeding a partial slice to ffmpeg yields a silently truncated
+        // transcode, so this body is unusable either way — discard it.
+        ;(attachment.data as Readable).destroy()
+
+        if (!forwardedRange) {
+          // Nothing to retry: we never sent a Range, so a Range-less re-fetch is
+          // byte-for-byte the same request and would pull a whole video again
+          // only to fail the same way.
+          console.error(
+            `Upstream returned an unsolicited partial response for video document ${ctx.params.documentId}`
+          )
+          refusePartialBody()
+          return
+        }
+
+        // We only learned this was a video after forwarding the client's Range,
+        // and upstream honoured it. Re-fetch the whole file once.
+        console.warn(
+          `Upstream returned a partial response for video document ${ctx.params.documentId}; re-fetching the full file`
+        )
+        attachment = await comprimaAdapter.getAttachment(document, undefined)
+        resolveTypeFromUpstream()
+
+        if (isVideoMp4 && isPartialResponse(attachment)) {
+          // Fail closed: a partial body must never reach the transcoder.
+          ;(attachment.data as Readable).destroy()
+          refusePartialBody()
+          return
+        }
+      }
+
+      const attachmentStream = attachment.data as Readable
 
       if (isVideoMp4) {
         const tmpPath = join(tmpdir(), `comprima-mp4-${randomBytes(8).toString('hex')}.mp4`)

--- a/packages/comprima-adapter/src/services/comprimaService/tests/index.test.ts
+++ b/packages/comprima-adapter/src/services/comprimaService/tests/index.test.ts
@@ -2,7 +2,28 @@ import request from 'supertest';
 import Koa from 'koa';
 import KoaRouter from '@koa/router';
 import bodyParser from 'koa-bodyparser';
+import { Readable, PassThrough } from 'stream';
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
+import { createWriteStream } from 'fs';
 import { routes } from '../index';
+import comprimaAdapter from '../comprimaAdapter';
+
+jest.mock('../comprimaAdapter');
+jest.mock('child_process', () => ({ spawn: jest.fn() }));
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    createWriteStream: jest.fn(),
+    createReadStream: jest.fn(),
+    unlink: jest.fn((_path: string, cb?: () => void) => cb && cb()),
+  };
+});
+
+const mockedComprimaAdapter = jest.mocked(comprimaAdapter);
+const mockedSpawn = jest.mocked(spawn);
+const mockedCreateWriteStream = jest.mocked(createWriteStream);
 
 const app = new Koa();
 const router = new KoaRouter();
@@ -10,12 +31,160 @@ routes(router);
 app.use(bodyParser());
 app.use(router.routes());
 
+const makeStream = (data = 'data') => {
+  const stream = new Readable();
+  stream.push(data);
+  stream.push(null);
+  return stream;
+};
+
+const makeDocument = (format: string, filename?: string) =>
+  ({
+    id: 1337,
+    fields: {
+      format: { value: format },
+      ...(filename ? { filename: { value: filename } } : {}),
+    },
+    pages: [{ url: 'http://comprima/attachment' }],
+  } as never);
+
+// Wires up a fake ffmpeg child that emits one transcoded chunk then closes, so
+// the transcode branch completes. Returns the spawn mock for assertions.
+const mockTranscodingFfmpeg = () => {
+  mockedCreateWriteStream.mockReturnValue(new PassThrough() as never);
+  mockedSpawn.mockImplementation((): never => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough;
+      stderr: EventEmitter;
+      kill: jest.Mock;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new EventEmitter();
+    child.kill = jest.fn();
+    setImmediate(() => {
+      child.stdout.end('transcoded');
+      child.emit('close', 0);
+    });
+    return child as never;
+  });
+};
+
 describe('comprimaService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /documents', () => {
     it('requires the levels query parameter', async () => {
       const res = await request(app.callback()).get('/documents');
       expect(res.status).toBe(400);
       expect(res.body.errorMessage).toBe('Missing parameter: level');
+    });
+  });
+
+  describe('GET /document/:documentId/attachment', () => {
+    it('forwards Range and 206/content-range for non-MP4 attachments', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(
+        makeDocument('image/jpeg')
+      );
+      mockedComprimaAdapter.getAttachment.mockResolvedValue({
+        data: makeStream(),
+        status: 206,
+        headers: {
+          'content-type': 'image/jpeg',
+          'content-range': 'bytes 0-100/200',
+          'accept-ranges': 'bytes',
+        },
+      } as never);
+
+      const res = await request(app.callback())
+        .get('/document/1337/attachment')
+        .set('Range', 'bytes=0-100');
+
+      expect(mockedComprimaAdapter.getAttachment).toBeCalledWith(
+        expect.anything(),
+        'bytes=0-100'
+      );
+      expect(res.status).toBe(206);
+      expect(res.headers['content-range']).toBe('bytes 0-100/200');
+      expect(res.headers['accept-ranges']).toBe('bytes');
+    });
+
+    it('transcodes MP4 and never forwards Range upstream', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(
+        makeDocument('video/mp4')
+      );
+      mockedComprimaAdapter.getAttachment.mockResolvedValue({
+        data: makeStream(),
+        status: 200,
+        headers: { 'content-type': 'video/mp4' },
+      } as never);
+
+      mockTranscodingFfmpeg();
+
+      const res = await request(app.callback())
+        .get('/document/1337/attachment')
+        .set('Range', 'bytes=0-100');
+
+      expect(mockedComprimaAdapter.getAttachment).toBeCalledWith(
+        expect.anything(),
+        undefined
+      );
+      expect(mockedSpawn).toHaveBeenCalled();
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('video/mp4');
+    });
+
+    it('passes through audio/mp4 without transcoding', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(
+        makeDocument('audio/mp4')
+      );
+      mockedComprimaAdapter.getAttachment.mockResolvedValue({
+        data: makeStream(),
+        status: 200,
+        headers: { 'content-type': 'audio/mp4' },
+      } as never);
+
+      const res = await request(app.callback()).get('/document/1337/attachment');
+
+      // The core regression guard: audio-only files must never reach the
+      // mandatory-video ffmpeg branch.
+      expect(mockedSpawn).not.toHaveBeenCalled();
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('audio/mp4');
+    });
+
+    it('transcodes no-MIME docs when the upstream content-type is video/mp4', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(makeDocument(''));
+      mockedComprimaAdapter.getAttachment.mockResolvedValue({
+        data: makeStream(),
+        status: 200,
+        headers: { 'content-type': 'video/mp4' },
+      } as never);
+
+      mockTranscodingFfmpeg();
+
+      const res = await request(app.callback()).get('/document/1337/attachment');
+
+      expect(mockedSpawn).toHaveBeenCalled();
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('video/mp4');
+    });
+
+    it('passes through no-MIME docs when the upstream content-type is audio/mp4', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(makeDocument(''));
+      mockedComprimaAdapter.getAttachment.mockResolvedValue({
+        data: makeStream(),
+        status: 200,
+        headers: { 'content-type': 'audio/mp4' },
+      } as never);
+
+      const res = await request(app.callback()).get('/document/1337/attachment');
+
+      // Hardened header path: the old includes('mp4') would have transcoded this.
+      expect(mockedSpawn).not.toHaveBeenCalled();
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('audio/mp4');
     });
   });
 });

--- a/packages/comprima-adapter/src/services/comprimaService/tests/index.test.ts
+++ b/packages/comprima-adapter/src/services/comprimaService/tests/index.test.ts
@@ -4,8 +4,9 @@ import KoaRouter from '@koa/router';
 import bodyParser from 'koa-bodyparser';
 import { Readable, PassThrough } from 'stream';
 import { EventEmitter } from 'events';
+import { createServer, Server } from 'http';
 import { spawn } from 'child_process';
-import { createWriteStream } from 'fs';
+import { createWriteStream, createReadStream, unlink } from 'fs';
 import { routes } from '../index';
 import comprimaAdapter from '../comprimaAdapter';
 
@@ -24,6 +25,8 @@ jest.mock('fs', () => {
 const mockedComprimaAdapter = jest.mocked(comprimaAdapter);
 const mockedSpawn = jest.mocked(spawn);
 const mockedCreateWriteStream = jest.mocked(createWriteStream);
+const mockedCreateReadStream = jest.mocked(createReadStream);
+const mockedUnlink = jest.mocked(unlink);
 
 const app = new Koa();
 const router = new KoaRouter();
@@ -67,6 +70,42 @@ const mockTranscodingFfmpeg = () => {
     });
     return child as never;
   });
+};
+
+// Wires up a spawn that fails the way a missing ffmpeg binary does: an 'error'
+// event followed by stdout ending without ever producing data.
+const mockMissingFfmpeg = () => {
+  mockedCreateWriteStream.mockReturnValue(new PassThrough() as never);
+  mockedSpawn.mockImplementation((): never => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough;
+      stderr: EventEmitter;
+      kill: jest.Mock;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new EventEmitter();
+    child.kill = jest.fn();
+    setImmediate(() => {
+      child.emit('error', new Error('spawn ffmpeg ENOENT'));
+      child.stdout.end();
+    });
+    return child as never;
+  });
+};
+
+const flushEvents = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+// Tests that tear the response down mid-flight leave sockets supertest never
+// closes, which keeps the jest worker alive. Own the server so we can close it.
+const withServer = async (fn: (server: Server) => Promise<void>) => {
+  const server = createServer(app.callback());
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  try {
+    await fn(server);
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
 };
 
 describe('comprimaService', () => {
@@ -185,6 +224,140 @@ describe('comprimaService', () => {
       expect(mockedSpawn).not.toHaveBeenCalled();
       expect(res.status).toBe(200);
       expect(res.headers['content-type']).toContain('audio/mp4');
+    });
+
+    it('creates the temp file owner-only', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(
+        makeDocument('video/mp4')
+      );
+      mockedComprimaAdapter.getAttachment.mockResolvedValue({
+        data: makeStream(),
+        status: 200,
+        headers: { 'content-type': 'video/mp4' },
+      } as never);
+
+      mockTranscodingFfmpeg();
+
+      await request(app.callback()).get('/document/1337/attachment');
+
+      // The buffered file may hold restricted archive content.
+      expect(mockedCreateWriteStream).toHaveBeenCalledWith(expect.any(String), {
+        mode: 0o600,
+      });
+    });
+
+    it('removes the temp file and never spawns ffmpeg when buffering fails', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(
+        makeDocument('video/mp4')
+      );
+      mockedComprimaAdapter.getAttachment.mockResolvedValue({
+        data: new PassThrough(),
+        status: 200,
+        headers: { 'content-type': 'video/mp4' },
+      } as never);
+
+      mockedCreateWriteStream.mockImplementation((): never => {
+        const ws = new PassThrough();
+        setImmediate(() => ws.emit('error', new Error('disk full')));
+        return ws as never;
+      });
+
+      const res = await request(app.callback()).get('/document/1337/attachment');
+
+      expect(res.status).toBe(500);
+      expect(mockedUnlink).toHaveBeenCalled();
+      expect(mockedSpawn).not.toHaveBeenCalled();
+    });
+
+    it('serves the buffered file when ffmpeg cannot be spawned', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(
+        makeDocument('video/mp4')
+      );
+      mockedComprimaAdapter.getAttachment.mockResolvedValue({
+        data: makeStream(),
+        status: 200,
+        headers: { 'content-type': 'video/mp4' },
+      } as never);
+
+      mockMissingFfmpeg();
+      // A real file read delivers asynchronously, i.e. after ffmpeg's stdout
+      // has already ended — which is what makes the end-race observable.
+      mockedCreateReadStream.mockImplementation((): never => {
+        const rs = new PassThrough();
+        setTimeout(() => rs.end('fallback-bytes'), 5);
+        return rs as never;
+      });
+
+      await withServer(async (server) => {
+        const res = await request(server)
+          .get('/document/1337/attachment')
+          .buffer(true);
+
+        // Regression guard: piping ffmpeg's (immediately ended) stdout with the
+        // default end:true would close the response before the fallback flowed.
+        expect(res.status).toBe(200);
+        expect((res.body as Buffer).toString()).toContain('fallback-bytes');
+        expect(mockedUnlink).toHaveBeenCalled();
+      });
+    });
+
+    it('does not hang when the fallback read stream fails', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(
+        makeDocument('video/mp4')
+      );
+      mockedComprimaAdapter.getAttachment.mockResolvedValue({
+        data: makeStream(),
+        status: 200,
+        headers: { 'content-type': 'video/mp4' },
+      } as never);
+
+      mockMissingFfmpeg();
+      mockedCreateReadStream.mockImplementation((): never => {
+        const rs = new PassThrough();
+        setImmediate(() => rs.emit('error', new Error('read failed')));
+        return rs as never;
+      });
+
+      await withServer(async (server) => {
+        try {
+          await request(server).get('/document/1337/attachment');
+        } catch {
+          /* the response is torn down; either outcome is fine, it must not hang */
+        }
+
+        await flushEvents();
+        expect(mockedUnlink).toHaveBeenCalled();
+      });
+    });
+
+    it('cleans up without transcoding when the client disconnects while buffering', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(
+        makeDocument('video/mp4')
+      );
+      mockedComprimaAdapter.getAttachment.mockResolvedValue({
+        data: new PassThrough(),
+        status: 200,
+        headers: { 'content-type': 'video/mp4' },
+      } as never);
+
+      // Never emits 'finish', so the request stays stuck in the buffering phase.
+      mockedCreateWriteStream.mockImplementation(
+        () => new PassThrough() as never
+      );
+
+      await withServer(async (server) => {
+        const req = request(server).get('/document/1337/attachment');
+        setTimeout(() => req.abort(), 50);
+        try {
+          await req;
+        } catch {
+          /* client-side abort */
+        }
+
+        await flushEvents();
+        expect(mockedUnlink).toHaveBeenCalled();
+        expect(mockedSpawn).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/comprima-adapter/src/services/comprimaService/tests/index.test.ts
+++ b/packages/comprima-adapter/src/services/comprimaService/tests/index.test.ts
@@ -41,6 +41,28 @@ const makeStream = (data = 'data') => {
   return stream;
 };
 
+// A partial video body: 206 + content-range, i.e. a slice ffmpeg must never see.
+const partialVideoResponse = (data: Readable) => ({
+  data,
+  status: 206,
+  headers: {
+    'content-type': 'video/mp4',
+    'content-range': 'bytes 0-100/2000',
+  },
+});
+
+// Collects whatever the transcode branch buffers to its temp file, so a test can
+// assert which body actually reached ffmpeg. Call after mockTranscodingFfmpeg().
+const captureBufferedFile = () => {
+  const chunks: Buffer[] = [];
+  mockedCreateWriteStream.mockImplementation((): never => {
+    const ws = new PassThrough();
+    ws.on('data', (chunk) => chunks.push(chunk as Buffer));
+    return ws as never;
+  });
+  return () => Buffer.concat(chunks).toString();
+};
+
 const makeDocument = (format: string, filename?: string) =>
   ({
     id: 1337,
@@ -221,6 +243,151 @@ describe('comprimaService', () => {
       const res = await request(app.callback()).get('/document/1337/attachment');
 
       // Hardened header path: the old includes('mp4') would have transcoded this.
+      expect(mockedSpawn).not.toHaveBeenCalled();
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('audio/mp4');
+    });
+
+    it('re-fetches without Range when a no-format doc turns out to be a 206 video/mp4', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(makeDocument(''));
+      const partial = makeStream('partial-slice');
+      mockedComprimaAdapter.getAttachment
+        .mockResolvedValueOnce(partialVideoResponse(partial) as never)
+        .mockResolvedValueOnce({
+          data: makeStream('full-body'),
+          status: 200,
+          headers: { 'content-type': 'video/mp4' },
+        } as never);
+
+      mockTranscodingFfmpeg();
+      const buffered = captureBufferedFile();
+
+      const res = await request(app.callback())
+        .get('/document/1337/attachment')
+        .set('Range', 'bytes=0-100');
+
+      // The Range is forwarded on the first hop (format is empty, so the doc is
+      // not yet known to be a video), then re-fetched in full once the upstream
+      // content-type flips it into the transcode branch.
+      expect(mockedComprimaAdapter.getAttachment).toHaveBeenCalledTimes(2);
+      expect(mockedComprimaAdapter.getAttachment).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        'bytes=0-100'
+      );
+      expect(mockedComprimaAdapter.getAttachment).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        undefined
+      );
+      // Only the complete second body may reach ffmpeg.
+      expect(partial.destroyed).toBe(true);
+      expect(buffered()).toBe('full-body');
+      expect(mockedSpawn).toHaveBeenCalled();
+      expect(res.status).toBe(200);
+    });
+
+    it('fails closed without transcoding when the re-fetch is still partial', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(makeDocument(''));
+      // Two distinct bodies: sharing one stream would let the second destroy()
+      // pass vacuously and leave the 502 path's socket cleanup unguarded.
+      const first = makeStream('partial-one');
+      const second = makeStream('partial-two');
+      mockedComprimaAdapter.getAttachment
+        .mockResolvedValueOnce(partialVideoResponse(first) as never)
+        .mockResolvedValueOnce(partialVideoResponse(second) as never);
+
+      mockTranscodingFfmpeg();
+
+      const res = await request(app.callback())
+        .get('/document/1337/attachment')
+        .set('Range', 'bytes=0-100');
+
+      expect(mockedComprimaAdapter.getAttachment).toHaveBeenCalledTimes(2);
+      expect(mockedSpawn).not.toHaveBeenCalled();
+      // Both discarded bodies must be destroyed or the upstream sockets leak.
+      expect(first.destroyed).toBe(true);
+      expect(second.destroyed).toBe(true);
+      expect(res.status).toBe(502);
+      expect(res.body.documentId).toBe('1337');
+    });
+
+    it('does not re-fetch when no Range was forwarded and upstream is partial anyway', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(
+        makeDocument('video/mp4')
+      );
+      const partial = makeStream('partial-slice');
+      mockedComprimaAdapter.getAttachment.mockResolvedValue(
+        partialVideoResponse(partial) as never
+      );
+
+      mockTranscodingFfmpeg();
+
+      const res = await request(app.callback()).get('/document/1337/attachment');
+
+      // Range is withheld for a doc already known to be video, so a Range-less
+      // retry is byte-for-byte the same request — it would pull a whole video
+      // again only to fail identically. Fail closed on the first response.
+      expect(mockedComprimaAdapter.getAttachment).toHaveBeenCalledTimes(1);
+      expect(mockedComprimaAdapter.getAttachment).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined
+      );
+      expect(partial.destroyed).toBe(true);
+      expect(mockedSpawn).not.toHaveBeenCalled();
+      expect(res.status).toBe(502);
+    });
+
+    it('treats a content-range on a 200 as a partial body', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(makeDocument(''));
+      const partial = makeStream('partial-slice');
+      mockedComprimaAdapter.getAttachment
+        .mockResolvedValueOnce({
+          ...partialVideoResponse(partial),
+          // A non-compliant upstream can answer 200 while still sending a slice.
+          status: 200,
+        } as never)
+        .mockResolvedValueOnce({
+          data: makeStream('full-body'),
+          status: 200,
+          headers: { 'content-type': 'video/mp4' },
+        } as never);
+
+      mockTranscodingFfmpeg();
+      const buffered = captureBufferedFile();
+
+      const res = await request(app.callback())
+        .get('/document/1337/attachment')
+        .set('Range', 'bytes=0-100');
+
+      expect(mockedComprimaAdapter.getAttachment).toHaveBeenCalledTimes(2);
+      expect(partial.destroyed).toBe(true);
+      expect(buffered()).toBe('full-body');
+      expect(mockedSpawn).toHaveBeenCalled();
+      expect(res.status).toBe(200);
+    });
+
+    it('re-derives the content type from the re-fetched response', async () => {
+      mockedComprimaAdapter.getDocument.mockResolvedValue(makeDocument(''));
+      mockedComprimaAdapter.getAttachment
+        .mockResolvedValueOnce(
+          partialVideoResponse(makeStream('partial-slice')) as never
+        )
+        .mockResolvedValueOnce({
+          data: makeStream('audio-body'),
+          status: 200,
+          headers: { 'content-type': 'audio/mp4' },
+        } as never);
+
+      mockTranscodingFfmpeg();
+
+      const res = await request(app.callback())
+        .get('/document/1337/attachment')
+        .set('Range', 'bytes=0-100');
+
+      // The transcode decision must describe the body we are about to serve, not
+      // the discarded one: hop 2 is audio-only, so it passes through untouched
+      // instead of being fed to the mandatory-video ffmpeg map.
       expect(mockedSpawn).not.toHaveBeenCalled();
       expect(res.status).toBe(200);
       expect(res.headers['content-type']).toContain('audio/mp4');

--- a/packages/reading-room-frontend/src/routes/search/components/documentViewer/components/VideoPlayer.tsx
+++ b/packages/reading-room-frontend/src/routes/search/components/documentViewer/components/VideoPlayer.tsx
@@ -22,6 +22,9 @@ export const VideoPlayer = ({ file, scale, rotation }: VideoPlayerProps) => {
         alignItems: 'center',
       }}
     >
+      {/* No caption track: archived videos have no caption resources, and
+          pointing one at the video URL triggers a failing transcode fetch. */}
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video
         controls
         playsInline
@@ -34,7 +37,6 @@ export const VideoPlayer = ({ file, scale, rotation }: VideoPlayerProps) => {
         controlsList="nodownload"
       >
         <source src={file.url} />
-        <track kind="captions" src={file.url} srcLang="en" label="English" />
         Din webbläsare stödjer inte videouppspelning.
       </video>
     </Box>

--- a/packages/reading-room-frontend/src/routes/search/components/documentViewer/components/VideoPlayer.tsx
+++ b/packages/reading-room-frontend/src/routes/search/components/documentViewer/components/VideoPlayer.tsx
@@ -33,7 +33,7 @@ export const VideoPlayer = ({ file, scale, rotation }: VideoPlayerProps) => {
         }}
         controlsList="nodownload"
       >
-        <source src={file.url} type="video/mp4" />
+        <source src={file.url} />
         <track kind="captions" src={file.url} srcLang="en" label="English" />
         Din webbläsare stödjer inte videouppspelning.
       </video>

--- a/packages/reading-room-search/jest.config.js
+++ b/packages/reading-room-search/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFiles: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {
     "axios": "axios/dist/node/axios.cjs"
   },

--- a/packages/reading-room-search/jest.setup.js
+++ b/packages/reading-room-search/jest.setup.js
@@ -1,0 +1,22 @@
+// Polyfill Web platform globals that undici (via @elastic/elasticsearch)
+// references at module-load time but which jest-environment-node's VM
+// sandbox does not expose. Guarded so this is a no-op where they exist.
+const { ReadableStream, WritableStream, TransformStream } = require('node:stream/web')
+const { TextEncoder, TextDecoder } = require('node:util')
+const { MessageChannel, MessagePort } = require('node:worker_threads')
+
+const globals = {
+  ReadableStream,
+  WritableStream,
+  TransformStream,
+  TextEncoder,
+  TextDecoder,
+  MessageChannel,
+  MessagePort,
+}
+
+for (const [name, value] of Object.entries(globals)) {
+  if (typeof globalThis[name] === 'undefined') {
+    globalThis[name] = value
+  }
+}

--- a/packages/reading-room-search/src/services/documentService/index.ts
+++ b/packages/reading-room-search/src/services/documentService/index.ts
@@ -23,7 +23,7 @@ const getAttachmentStream = async (id: string, rangeHeader?: string) => {
     method: 'get',
     url: url,
     responseType: 'stream',
-    headers: rangeHeader ? { Range: rangeHeader } : {},
+    ...(rangeHeader ? { headers: { Range: rangeHeader } } : {}),
   })
 
   return response

--- a/packages/reading-room-search/src/services/documentService/index.ts
+++ b/packages/reading-room-search/src/services/documentService/index.ts
@@ -14,7 +14,7 @@ class DocumentNotFoundError extends Error {
   }
 }
 
-const getAttachmentStream = async (id: string) => {
+const getAttachmentStream = async (id: string, rangeHeader?: string) => {
   const url = `${
     config.comprimaAdapter?.url || 'https://comprima.dev.cfn.iteam.se'
   }/document/${id}/attachment`
@@ -23,6 +23,7 @@ const getAttachmentStream = async (id: string) => {
     method: 'get',
     url: url,
     responseType: 'stream',
+    headers: rangeHeader ? { Range: rangeHeader } : {},
   })
 
   return response
@@ -188,8 +189,20 @@ export const routes = (router: KoaRouter) => {
         return
       }
 
-      const response = await getAttachmentStream(id)
+      const rangeHeader = ctx.request.headers['range'] as string | undefined
+      const response = await getAttachmentStream(id, rangeHeader)
       ctx.type = response.headers['content-type']?.toString() ?? 'image/jpeg'
+
+      if (response.headers['content-range']) {
+        ctx.response.set('content-range', response.headers['content-range'])
+      }
+      if (response.headers['accept-ranges']) {
+        ctx.response.set('accept-ranges', response.headers['accept-ranges'])
+      }
+      if (response.status === 206) {
+        ctx.status = 206
+      }
+
       ctx.body = response.data
     } catch (err) {
       if (err instanceof DocumentNotFoundError) {

--- a/packages/reading-room-search/src/services/documentService/index.ts
+++ b/packages/reading-room-search/src/services/documentService/index.ts
@@ -2,7 +2,7 @@ import KoaRouter from '@koa/router'
 import { Client, errors } from '@elastic/elasticsearch'
 import { Document } from '../../common/types'
 import config from '../../common/config'
-import axios from 'axios'
+import axios, { AxiosError } from 'axios'
 import fs from 'fs'
 
 class DocumentNotFoundError extends Error {
@@ -12,26 +12,6 @@ class DocumentNotFoundError extends Error {
     // Set the prototype explicitly.
     Object.setPrototypeOf(this, DocumentNotFoundError.prototype)
   }
-}
-
-// Axios rejects on non-2xx, so an adapter error surfaces here as an error with
-// a `response` property rather than as a return value. The adapter fails closed
-// with shaped 5xx responses (e.g. 502 for a partial upstream video body) that
-// must reach the client instead of being flattened to a generic 500.
-const getUpstream5xxResponse = (err: unknown) => {
-  const response = (
-    err as {
-      response?: {
-        status: number
-        headers: Record<string, string | undefined>
-        data: unknown
-      }
-    }
-  )?.response
-
-  return typeof response?.status === 'number' && response.status >= 500
-    ? response
-    : undefined
 }
 
 const getAttachmentStream = async (id: string, rangeHeader?: string) => {
@@ -228,22 +208,22 @@ export const routes = (router: KoaRouter) => {
       if (err instanceof DocumentNotFoundError) {
         ctx.status = 404
         ctx.body = { results: 'error: document not found' }
-        return
+      } else if (
+        err instanceof AxiosError &&
+        err.response &&
+        err.response.status >= 500
+      ) {
+        // The adapter fails closed with shaped 5xx responses (e.g. 502 for a
+        // partial upstream video body) — mirror status and body instead of
+        // flattening them to a generic 500.
+        ctx.status = err.response.status
+        ctx.type =
+          err.response.headers['content-type']?.toString() ?? 'application/json'
+        ctx.body = err.response.data
+      } else {
+        ctx.status = 500
+        ctx.body = { results: 'error: ' + err }
       }
-
-      const upstream = getUpstream5xxResponse(err)
-      if (upstream) {
-        ctx.status = upstream.status
-        if (upstream.headers['content-type']) {
-          ctx.type = upstream.headers['content-type']
-        }
-        // With responseType 'stream' the error body is a Readable; Koa pipes it.
-        ctx.body = upstream.data
-        return
-      }
-
-      ctx.status = 500
-      ctx.body = { results: 'error: ' + err }
     }
   })
 

--- a/packages/reading-room-search/src/services/documentService/index.ts
+++ b/packages/reading-room-search/src/services/documentService/index.ts
@@ -14,6 +14,26 @@ class DocumentNotFoundError extends Error {
   }
 }
 
+// Axios rejects on non-2xx, so an adapter error surfaces here as an error with
+// a `response` property rather than as a return value. The adapter fails closed
+// with shaped 5xx responses (e.g. 502 for a partial upstream video body) that
+// must reach the client instead of being flattened to a generic 500.
+const getUpstream5xxResponse = (err: unknown) => {
+  const response = (
+    err as {
+      response?: {
+        status: number
+        headers: Record<string, string | undefined>
+        data: unknown
+      }
+    }
+  )?.response
+
+  return typeof response?.status === 'number' && response.status >= 500
+    ? response
+    : undefined
+}
+
 const getAttachmentStream = async (id: string, rangeHeader?: string) => {
   const url = `${
     config.comprimaAdapter?.url || 'https://comprima.dev.cfn.iteam.se'
@@ -208,10 +228,22 @@ export const routes = (router: KoaRouter) => {
       if (err instanceof DocumentNotFoundError) {
         ctx.status = 404
         ctx.body = { results: 'error: document not found' }
-      } else {
-        ctx.status = 500
-        ctx.body = { results: 'error: ' + err }
+        return
       }
+
+      const upstream = getUpstream5xxResponse(err)
+      if (upstream) {
+        ctx.status = upstream.status
+        if (upstream.headers['content-type']) {
+          ctx.type = upstream.headers['content-type']
+        }
+        // With responseType 'stream' the error body is a Readable; Koa pipes it.
+        ctx.body = upstream.data
+        return
+      }
+
+      ctx.status = 500
+      ctx.body = { results: 'error: ' + err }
     }
   })
 

--- a/packages/reading-room-search/src/services/documentService/index.ts
+++ b/packages/reading-room-search/src/services/documentService/index.ts
@@ -189,7 +189,7 @@ export const routes = (router: KoaRouter) => {
         return
       }
 
-      const rangeHeader = ctx.request.headers['range'] as string | undefined
+      const rangeHeader = ctx.request.headers['range']
       const response = await getAttachmentStream(id, rangeHeader)
       ctx.type = response.headers['content-type']?.toString() ?? 'image/jpeg'
 

--- a/packages/reading-room-search/src/services/documentService/tests/index.test.ts
+++ b/packages/reading-room-search/src/services/documentService/tests/index.test.ts
@@ -371,6 +371,25 @@ describe('documentService', () => {
       })
     })
 
+    it('forwards the Range header to comprima-adapter when present', async () => {
+      const id = '1337'
+      mockedAxios.mockReturnValue(
+        Promise.resolve('SUCCESS') as Promise<unknown>
+      )
+
+      await request(app.callback())
+        .get(`/document/${id}/attachment/filename.jpg`)
+        .set('Range', 'bytes=0-100')
+        .set('Authorization', 'Bearer ' + token)
+
+      expect(mockedAxios).toBeCalledWith({
+        method: 'get',
+        responseType: 'stream',
+        url: `${config.comprimaAdapter.url}/document/${id}/attachment`,
+        headers: { Range: 'bytes=0-100' },
+      })
+    })
+
     it("returns 404 if user doesn't have access to that document", async () => {
       const id = '1337'
       mockedAxios.mockReturnValue(

--- a/packages/reading-room-search/src/services/documentService/tests/index.test.ts
+++ b/packages/reading-room-search/src/services/documentService/tests/index.test.ts
@@ -390,6 +390,49 @@ describe('documentService', () => {
       })
     })
 
+    it('passes an upstream 5xx status and body through to the client', async () => {
+      jest.spyOn(Client.prototype, 'get').mockResolvedValue(documentResultMock)
+      const id = '1337'
+      const upstreamBody = {
+        errorMessage:
+          'Upstream returned a partial response for a video attachment; cannot transcode a partial body',
+        documentId: id,
+      }
+      const bodyStream = new Readable()
+      bodyStream.push(JSON.stringify(upstreamBody))
+      bodyStream.push(null)
+
+      mockedAxios.mockRejectedValue(
+        Object.assign(new Error('Request failed with status code 502'), {
+          response: {
+            status: 502,
+            headers: { 'content-type': 'application/json; charset=utf-8' },
+            data: bodyStream,
+          },
+        })
+      )
+
+      const res = await request(app.callback())
+        .get(`/document/${id}/attachment/filename.mp4`)
+        .set('Authorization', 'Bearer ' + token)
+
+      expect(res.status).toEqual(502)
+      expect(res.body).toEqual(upstreamBody)
+    })
+
+    it('returns 500 when the adapter request fails without a response', async () => {
+      jest.spyOn(Client.prototype, 'get').mockResolvedValue(documentResultMock)
+      const id = '1337'
+      mockedAxios.mockRejectedValue(new Error('ECONNREFUSED'))
+
+      const res = await request(app.callback())
+        .get(`/document/${id}/attachment/filename.mp4`)
+        .set('Authorization', 'Bearer ' + token)
+
+      expect(res.status).toEqual(500)
+      expect(res.text).toEqual('{"results":"error: Error: ECONNREFUSED"}')
+    })
+
     it("returns 404 if user doesn't have access to that document", async () => {
       const id = '1337'
       mockedAxios.mockReturnValue(

--- a/packages/reading-room-search/src/services/documentService/tests/index.test.ts
+++ b/packages/reading-room-search/src/services/documentService/tests/index.test.ts
@@ -3,7 +3,7 @@ import Koa from 'koa'
 import KoaRouter from '@koa/router'
 import bodyParser from '@koa/bodyparser'
 import { Client } from '@elastic/elasticsearch'
-import axios from 'axios'
+import axios, { AxiosError, AxiosResponse } from 'axios'
 import { routes } from '../index'
 import documentResultMock from './documentResultMock'
 import config from '../../../common/config'
@@ -402,15 +402,15 @@ describe('documentService', () => {
       bodyStream.push(JSON.stringify(upstreamBody))
       bodyStream.push(null)
 
-      mockedAxios.mockRejectedValue(
-        Object.assign(new Error('Request failed with status code 502'), {
-          response: {
-            status: 502,
-            headers: { 'content-type': 'application/json; charset=utf-8' },
-            data: bodyStream,
-          },
-        })
+      const upstreamError = new AxiosError(
+        'Request failed with status code 502'
       )
+      upstreamError.response = {
+        status: 502,
+        headers: { 'content-type': 'application/json; charset=utf-8' },
+        data: bodyStream,
+      } as unknown as AxiosResponse
+      mockedAxios.mockRejectedValue(upstreamError)
 
       const res = await request(app.callback())
         .get(`/document/${id}/attachment/filename.mp4`)


### PR DESCRIPTION
The video playback bug is caused by the following issues:

- The video files are using codec MPEG-4 Part 2 which is not supported by browsers since at least 2015
- The moov metadata atom in the MP4 video files is positioned at the end of the file
- Comprima server is not supporting the Range request header

Audio is already using AAC as codec which is correct.

The moov atom is the part of the mp4 file container that contains the metadata that tells the browser how to decode it and initialize playback. In these MP4 files they are located at the end of the file, after the mdat atom that contains the media data. Browsers require either the moov atom at the beginning (faststart) or range request support to seek to it. Comprima supports neither.

The range-forwarding code implementation forwards the Range header that solves the issue for servers supporting it. Comprima always returns 200, so the browser never receives a 206 Partial Content response and falls back to linear decoding from byte 0, where it finds audio frames (audio appears early in the file container) but cannot find the video track metadata.

Converting to fragmented MP4 (frag_keyframe+empty_moov) places an empty_moov and self-contained moof/mdat fragments at the start of the stream, which the browser can decode from byte 0 without seeking.

The Range request header and/or reordering the container to place the moov atom before mdat is not enough to solve the issue, which is why ffmpeg also converts the video codec from MPEG-4 Part 2 to H.264 (MPEG-4 Part 10).

Drawbacks:
Writing a temporary file is a security risk (albeit small in this context), as well as causing disk usage and cleanup of temp files. It's also causing significant latency compared to receiving a video optimized for browser playback directly in the response. A more permanent and efficient solution is therefore to transcode the stored video files. 